### PR TITLE
DHT11 import issue, packaging and readme fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,94 @@
-================================
-foglamp-south-dht11 Raspberry Pi
-================================
+==================================
+foglamp-south-dht11 (Raspberry Pi)
+==================================
 
-FogLAMP South Plugin for DHT11 (For Raspberry Pi)
+FogLAMP South Plugin for DHT11 temperature and humidity sensor, for Raspberry Pi.
+
+
+Hardware
+========
+
+A DHT11 pluged directly into the GPIO pins of a Raspberry Pi, the default configuration is to use GPIO4 for the data.
+
+
+Installation
+============
+
+
+Create Debian Package
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: console
+
+    $ ./make_deb help
+    make_deb {arm} [clean|cleanall]
+    This script is used to create the Debian package of foglamp dht11 plugin
+
+    Arguments:
+     arm      - Build an armv7l package
+     clean    - Remove all the old versions saved in format .XXXX
+     cleanall - Remove all the versions, including the last one
+
+``./make_deb arm`` will create the debian package inside ``packages/Debian/build/``.
+
+
+Pre Debian Package Install
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This plugin uses the Adafruit_Python_DHT python package. There is a known issue with pip package.
+
+https://github.com/adafruit/Adafruit_Python_DHT/issues/99
+
+Hence to install this, perform the following steps:
+
+.. code-block:: bash
+
+   git clone https://github.com/adafruit/Adafruit_Python_DHT.git
+   cd Adafruit_Python_DHT
+   sudo apt-get install build-essential python3-dev
+   sudo python3 setup.py install
+
+
+Sensor GPIO access
+~~~~~~~~~~~~~~~~~~
+
+To access the GPIO pins foglamp must be able to access ``/dev/gpiomem``, the default access for this is owner and group read/write.
+Either FogLAMP must be added to the group or the permissions altered to allow FogLAMP access to the sensor.
+
+
+Install Debian Package
+~~~~~~~~~~~~~~~~~~~~~~
+
+Make sure FogLAMP is installed and running.
+
+.. code-block:: console
+
+  $ sudo systemctl status foglamp.service
+
+
+Once you have created the debian package, install it using the ``apt`` command. Move the package to the apt cache directory
+i.e. ``/var/cache/apt/archives``.
+
+.. code-block:: console
+
+  $ sudo cp foglamp-south-dht11-1.0.0-armhf.deb /var/cache/apt/archives/.
+  $ sudo apt install /var/cache/apt/archives/foglamp-south-dht11-1.0.0-armhf.deb
+
+
+Check the newly installed package:
+
+.. code-block:: console
+
+  $ sudo dpkg -l | grep foglamp-south-dht11
+
+
+Check foglamp service status for foglamp-south-dht11, it should list it as a south service:
+
+.. code-block:: console
+
+  $ sudo systemctl status foglamp.service
+  ...
+  ...
+  CGroup: /system.slice/foglamp.service
+           |- ....
+           └─python3 -m foglamp.services.south --port=43927 --address=127.0.0.1 --name=dht11

--- a/VERSION.south.dht11
+++ b/VERSION.south.dht11
@@ -1,2 +1,2 @@
 foglamp_south_dht11_version=1.0.1
-foglamp_version=1.2
+foglamp_version=1.3

--- a/VERSION.south.dht11
+++ b/VERSION.south.dht11
@@ -1,2 +1,2 @@
-foglamp_south_dht11_version=1.0.0
+foglamp_south_dht11_version=1.0.1
 foglamp_version=1.2

--- a/packages/Debian/armhf/DEBIAN/postinst
+++ b/packages/Debian/armhf/DEBIAN/postinst
@@ -27,15 +27,20 @@
 
 set -e
 
+install_deps () {
+    pip3 install -Ir /usr/local/foglamp/python/requirements-dht.txt --no-cache-dir
+}
+
 set_files_ownership () {
     chown -R root:root /usr/local/foglamp/python/foglamp/plugins/south/dht11
 }
 
 add_service () {
-    output=$(curl -sX POST http://localhost:8081/foglamp/service -d '{"name": "DHT 11", "type": "south", "plugin": "dht11", "enabled": true}')
+    output=$(curl -sX POST http://localhost:8081/foglamp/service -d '{"name": "dht11", "type": "south", "plugin": "dht11", "enabled": true}')
     echo $output
 }
 
+# install_deps  # FIXME: https://github.com/adafruit/Adafruit_Python_DHT/issues/99
 set_files_ownership
 add_service
 echo "dht11 plugin installed."

--- a/python/foglamp/plugins/south/dht11/README.rst
+++ b/python/foglamp/plugins/south/dht11/README.rst
@@ -1,31 +1,4 @@
 A FogLAMP South plugin for the DHT11
 ====================================
 
-A simple sensor plugin for a DHT11 temperature and humidity sensor. This
-plugin uses the DHT11 library available from Adafruit
-
-Hardware
-========
-
-A DHT11 pluged directly into the GPIO pins of a Raspberry Pi, the default
-configuration is to use GPIO4 for the data from the DHT11.
-
-
-Installation
-============
-
-Plugin for a DHT11 temperature and humidity sensor attached directly to the GPIO pins of a Raspberry Pi.
-
-This plugin uses the Adafruit DHT library, to install this, perform the following steps:
-
-.. code-block:: bash
-
-        git clone https://github.com/adafruit/Adafruit_Python_DHT.git
-        cd Adafruit_Python_DHT
-        sudo apt-get install build-essential python-dev
-        sudo python setup.py install
-
-To access the GPIO pins foglamp must be able to access ``/dev/gpiomem``, the default access for this is owner and group read/write.
-Either FogLAMP must be added to the group or the permissions altered to allow FogLAMP access to the sensor.
-
-
+A simple sensor plugin for a DHT11 temperature and humidity sensor, for Raspberry Pi.

--- a/python/foglamp/plugins/south/dht11/dht11.py
+++ b/python/foglamp/plugins/south/dht11/dht11.py
@@ -4,29 +4,19 @@
 # See: http://foglamp.readthedocs.io/
 # FOGLAMP_END
 
-""" Plugin for a DHT11 temperature and humidity sensor attached directly
-    to the GPIO pins of a Raspberry Pi
-
-    This plugin uses the Adafruit DHT library, to install this perform
-    the following steps:
-
-        git clone https://github.com/adafruit/Adafruit_Python_DHT.git
-        cd Adafruit_Python_DHT
-        sudo apt-get install build-essential python-dev
-        sudo python setup.py install
-
-    To access the GPIO pins foglamp must be able to access /dev/gpiomem,
-    the default access for this is owner and group read/write. Either
-    FogLAMP must be added to the group or the permissions altered to
-    allow FogLAMP access to the sensor.
-    """
-
+""" Plugin for a DHT11 temperature and humidity sensor attached directly to the GPIO pins of a Raspberry Pi. """
 
 from datetime import datetime, timezone
+import copy
 import uuid
+import logging
+
+# TODO: https://github.com/adafruit/Adafruit_Python_DHT/issues/99
+import Adafruit_DHT
 
 from foglamp.common import logger
 from foglamp.services.south import exceptions
+
 
 __author__ = "Mark Riddoch"
 __copyright__ = "Copyright (c) 2017 OSIsoft, LLC"
@@ -54,6 +44,7 @@ _DEFAULT_CONFIG = {
 
 _LOGGER = logger.setup(__name__)
 """ Setup the access to the logging system of FogLAMP """
+_LOGGER.setLevel(logging.INFO)
 
 
 def plugin_info():
@@ -85,7 +76,7 @@ def plugin_init(config):
     Raises:
     """
 
-    handle = config['gpiopin']['value']
+    handle = config
     return handle
 
 
@@ -136,8 +127,11 @@ def plugin_reconfigure(handle, new_config):
         new_handle: new handle to be used in the future calls
     Raises:
     """
+    _LOGGER.info("Old config for DHT11 plugin {} \n new config {}".format(handle, new_config))
 
-    new_handle = new_config['gpiopin']['value']
+    new_handle = copy.deepcopy(handle)
+    new_handle['restart'] = 'no'
+
     return new_handle
 
 

--- a/python/foglamp/plugins/south/dht11/dht11.py
+++ b/python/foglamp/plugins/south/dht11/dht11.py
@@ -95,7 +95,7 @@ def plugin_poll(handle):
     """
 
     try:
-        humidity, temperature = Adafruit_DHT.read_retry(Adafruit_DHT.DHT11, handle)
+        humidity, temperature = Adafruit_DHT.read_retry(Adafruit_DHT.DHT11, handle['gpiopin']['value'])
         if humidity is not None and temperature is not None:
             time_stamp = str(datetime.now(tz=timezone.utc))
             readings = {'temperature': temperature, 'humidity': humidity}

--- a/python/foglamp/plugins/south/dht11/dht11.py
+++ b/python/foglamp/plugins/south/dht11/dht11.py
@@ -105,14 +105,12 @@ def plugin_poll(handle):
                     'key':       str(uuid.uuid4()),
                     'readings':  readings
             }
-            return wrapper
         else:
-            return None
-
-    except Exception as ex:
-        raise exceptions.DataRetrievalError(ex)
-
-    return None
+            raise exceptions.DataRetrievalError
+    except Exception:
+        raise
+    else:
+        return wrapper
 
 
 def plugin_reconfigure(handle, new_config):

--- a/python/requirements-dht.txt
+++ b/python/requirements-dht.txt
@@ -1,0 +1,1 @@
+Adafruit_Python_DHT==1.3.2


### PR DESCRIPTION
- [x] Fix README and add info for creating and installing as a debian package 
- [x] Added info why pip3 dep does not work and we need to build package manually, to use plugin
- [x] Fix config handle
- [x] FOGL-1533 workaround
- [x] Testing

- [ ] revisit docs/06_plugins/03_01_DHT11.rst and docs/06_plugins/02_writing_plugins.rst
- [ ] Add https://s3.amazonaws.com/foglamp/docs/v1/Common/plugins/South/DHT11/DHT11-RaspPI-pins.jpg  with DHT11 sensor mapping