### PR TITLE
FOGL-2509 debian control, postinst and requirements fixes

### DIFF
--- a/VERSION.south.dht11
+++ b/VERSION.south.dht11
@@ -1,2 +1,2 @@
-foglamp_south_dht11_version=1.1.0
-foglamp_version>=1.4
+foglamp_south_dht11_version=1.5.0
+foglamp_version>=1.5

--- a/packages/Debian/armhf/DEBIAN/control
+++ b/packages/Debian/armhf/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.0.0
 Section: devel
 Priority: optional
 Architecture: armhf 
-Depends: build-essential,python3-dev,foglamp
+Depends: foglamp,wiringpi
 Conflicts:
 Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
 Homepage: http://www.dianomic.com

--- a/packages/Debian/armhf/DEBIAN/postinst
+++ b/packages/Debian/armhf/DEBIAN/postinst
@@ -35,6 +35,6 @@ set_files_ownership () {
     chown -R root:root /usr/local/foglamp/python/foglamp/plugins/south/dht11
 }
 
-# install_deps  # FIXME: https://github.com/adafruit/Adafruit_Python_DHT/issues/99
+install_deps
 set_files_ownership
 echo "dht11 plugin installed."

--- a/python/foglamp/plugins/south/dht11/dht11.py
+++ b/python/foglamp/plugins/south/dht11/dht11.py
@@ -64,7 +64,7 @@ def plugin_info():
 
     return {
         'name': 'DHT11 GPIO',
-        'version': '1.0',
+        'version': '1.5.0',
         'mode': 'poll',
         'type': 'south',
         'interface': '1.0',

--- a/python/requirements-dht.txt
+++ b/python/requirements-dht.txt
@@ -1,1 +1,1 @@
-Adafruit_Python_DHT==1.3.2
+Adafruit_Python_DHT==1.3.3

--- a/test/test_dht11.py
+++ b/test/test_dht11.py
@@ -28,7 +28,7 @@ def test_plugin_contract():
 def test_plugin_info():
     assert dht11.plugin_info() == {
         'name': 'DHT11 GPIO',
-        'version': '1.0',
+        'version': '1.5.0',
         'mode': 'poll',
         'type': 'south',
         'interface': '1.0',


### PR DESCRIPTION
```
$ sudo apt install /var/cache/apt/archives/foglamp-south-dht11-1.5.0-armhf.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'foglamp-south-dht11' instead of '/var/cache/apt/archives/foglamp-south-dht11-1.5.0-armhf.deb'
The following NEW packages will be installed:
  foglamp-south-dht11
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/3,084 B of archives.
After this operation, 0 B of additional disk space will be used.
Selecting previously unselected package foglamp-south-dht11.
(Reading database ... 49890 files and directories currently installed.)
Preparing to unpack .../foglamp-south-dht11-1.5.0-armhf.deb ...
Unpacking foglamp-south-dht11 (1.5.0) ...
Setting up foglamp-south-dht11 (1.5.0) ...
Collecting Adafruit_Python_DHT==1.3.3 (from -r /usr/local/foglamp/python/requirements-dht.txt (line 1))
  Downloading https://www.piwheels.org/simple/adafruit-python-dht/Adafruit_Python_DHT-1.3.3-cp35-cp35m-linux_armv7l.whl
Installing collected packages: Adafruit-Python-DHT
Successfully installed Adafruit-Python-DHT-1.3.3
dht11 plugin installed.

```

Discovery issue fixed from debian now